### PR TITLE
First pass zoom feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0">
     <title>settle</title>
   </head>
   <body style="margin:5px">

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="wrap">
+  <div class="wrap" :style="style">
+    <Zoom @zoom100="zoom100" @zoomSeeAll="zoomSeeAll"/>
     <div class="grid">
       <div v-for="y in rangeY" :key="y">
         <div class="tile" v-for="x in rangeX" :key="x">
@@ -12,8 +13,14 @@
 
 <script>
 import Tile from './Tile'
+import Zoom from './Zoom'
 
 export default {
+  data () {
+    return {
+      zoomLevel: 1.0
+    }
+  },
   props: {
     grid: {
       type: Object
@@ -47,6 +54,11 @@ export default {
         rs.push(x++)
       }
       return rs.reverse()
+    },
+    style () {
+      return {
+        '--zoom-level': this.zoomLevel
+      }
     }
   },
   methods: {
@@ -78,10 +90,17 @@ export default {
         return tile.meepleSelectColor
       }
       return null
+    },
+    zoom100 () {
+      this.zoomLevel = 1
+    },
+    zoomSeeAll () {
+      this.zoomLevel = 0.5
     }
   },
   components: {
-    Tile
+    Tile,
+    Zoom
   }
 }
 </script>
@@ -97,12 +116,15 @@ export default {
   overflow-x: scroll;
   overflow-y: scroll;
   line-height: 0;
-  height: 100%;
+  height: calc(100% * (1 / var(--zoom-level)));
+  width: calc(100% * (1 / var(--zoom-level)));
   position: absolute;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
+  transform: scale(var(--zoom-level));
+  transform-origin: top left;
 }
 .tile {
   position: relative;

--- a/src/components/Zoom.vue
+++ b/src/components/Zoom.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="zoom-control">
+    <button @click="$emit('zoom100')" class="zoom-button">100%</button>
+    <button @click="$emit('zoomSeeAll')" class="zoom-button">See all</button>
+  </div>
+</template>
+
+<script>
+</script>
+
+<style scoped lang="scss">
+.zoom-control {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: white;
+  z-index: 9999;
+}
+.zoom-button {
+  height: 32px;
+}
+</style>


### PR DESCRIPTION
### What

* Set maximum-scale to 1.0 on viewport to attempt to force usage of the feature rather than trying pinch to zoom
* Create Zoom component that emits `zoom100` and `zoomSeeAll` events
* Board uses those events to maintain a zoomLevel state that is currently either 1.0 or 0.5
* style method exposes CSS variables on the wrap div and its children
* Use a CSS transform to transform the element. Use the same var to control the width and height so that they stay 100% of the parent regardless of the zoom level

### Suggested changes

* Put thought into the z-index value for the zoom controls (I just found that `1` wasn't enough so put `9999`)
* Instead of multiple events, have a single `zoomChanged` event that provides a structure which has either an absolute zoom level (e.g. 0.5) or a user intended zoom level such as "fit to screen"
* Better styling on the controls. I imagine a slider and a "fit" button could be good
* Actually implement "fit to screen"